### PR TITLE
Draft: Added constructor , fix test deployment 

### DIFF
--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -53,8 +53,10 @@ pub mod Coiton {
 
 
     #[constructor]
-    fn constructor(ref self: ContractState, owner: ContractAddress) {
+    fn constructor(ref self: ContractState, owner: ContractAddress, coiton_erc20: ContractAddress, coiton_erc721: ContractAddress) {
         self.owner.write(owner);
+        self.erc20.write(coiton_erc20);
+        self.erc721.write(coiton_erc721);
     }
 
     #[abi(embed_v0)]


### PR DESCRIPTION
Check the error on the ERC721 and ERC20, so create a listing test that will hit those errors.

Without this block on the create_listing test 
` start_cheat_caller_address(coiton_contract_address, Owner);
    coiton.set_erc721(coiton_erc721);
    stop_cheat_caller_address(coiton_contract_address);`

Only owner error will display
error from the safe_mint function in the erc721  will display 

Note This error is also on the mint function in the ERC20.